### PR TITLE
Planar tilting

### DIFF
--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -92,6 +92,7 @@ namespace gazebo {
       double rot_;
       bool alive_;
       bool enable_y_axis_; ///< Enable Y-axis movement.
+      bool disable_pitch_and_roll_;
       common::Time last_odom_publish_time_;
       ignition::math::Pose3d last_odom_pose_;
 

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -52,7 +52,7 @@ namespace gazebo {
       void Load(physics::ModelPtr parent, sdf::ElementPtr sdf);
 
     protected:
-      virtual void UpdateChild();
+      virtual void UpdateChildBegin();
       virtual void UpdateChildEnd();
       virtual void FiniChild();
 
@@ -60,8 +60,8 @@ namespace gazebo {
       void publishOdometry(double step_time);
 
       physics::ModelPtr parent_;
-      event::ConnectionPtr update_connection_;
-      event::ConnectionPtr update_connection2_;
+      event::ConnectionPtr update_connection_begin_;
+      event::ConnectionPtr update_connection_end_;
 
       boost::shared_ptr<ros::NodeHandle> rosnode_;
       ros::Publisher odometry_pub_;

--- a/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
+++ b/gazebo_plugins/include/gazebo_plugins/gazebo_ros_planar_move.h
@@ -53,6 +53,7 @@ namespace gazebo {
 
     protected:
       virtual void UpdateChild();
+      virtual void UpdateChildEnd();
       virtual void FiniChild();
 
     private:
@@ -60,6 +61,7 @@ namespace gazebo {
 
       physics::ModelPtr parent_;
       event::ConnectionPtr update_connection_;
+      event::ConnectionPtr update_connection2_;
 
       boost::shared_ptr<ros::NodeHandle> rosnode_;
       ros::Publisher odometry_pub_;

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -63,6 +63,17 @@ namespace gazebo
       enable_y_axis_ = sdf->GetElement("enableYAxis")->Get<bool>();
     }
 
+    disable_pitch_and_roll_ = false;
+    if (!sdf->HasElement ("disablePitchAndRoll"))
+    {
+      ROS_INFO_NAMED("planar_move", "PlanarMovePlugin missing <disablePitchAndRoll>, "
+          "defaults to \"%d\"", disable_pitch_and_roll_);
+    }
+    else
+    {
+      disable_pitch_and_roll_ = sdf->GetElement("disablePitchAndRoll")->Get<bool>();
+    }
+
     command_topic_ = "cmd_vel";
     if (!sdf->HasElement("commandTopic"))
     {
@@ -173,9 +184,15 @@ namespace gazebo
       event::Events::ConnectWorldUpdateBegin(
           boost::bind(&GazeboRosPlanarMove::UpdateChildBegin, this));
     
-    update_connection_end_ =
-      event::Events::ConnectWorldUpdateEnd(
-          boost::bind(&GazeboRosPlanarMove::UpdateChildEnd, this));
+    if (disable_pitch_and_roll_ == true)
+    {
+      ROS_WARN_NAMED("planar_move", "PlanarMovePlugin (ns = %s) has <disablePitchAndRoll> to true, that means robot cannot move through slopes",
+          robot_namespace_.c_str());
+
+      update_connection_end_ =
+        event::Events::ConnectWorldUpdateEnd(
+            boost::bind(&GazeboRosPlanarMove::UpdateChildEnd, this));
+    }
 
   }
 

--- a/gazebo_plugins/src/gazebo_ros_planar_move.cpp
+++ b/gazebo_plugins/src/gazebo_ros_planar_move.cpp
@@ -172,6 +172,10 @@ namespace gazebo
     update_connection_ =
       event::Events::ConnectWorldUpdateBegin(
           boost::bind(&GazeboRosPlanarMove::UpdateChild, this));
+    
+    update_connection2_ =
+      event::Events::ConnectWorldUpdateEnd(
+          boost::bind(&GazeboRosPlanarMove::UpdateChildEnd, this));
 
   }
 
@@ -181,15 +185,20 @@ namespace gazebo
     boost::mutex::scoped_lock scoped_lock(lock);
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Pose3d pose = parent_->WorldPose();
+    ignition::math::Vector3d current_linear_velocity = parent_->RelativeLinearVel();
+    ignition::math::Vector3d current_angular_velocity = parent_->RelativeAngularVel();
 #else
     ignition::math::Pose3d pose = parent_->GetWorldPose().Ign();
+    ignition::math::Vector3d current_linear_velocity = parent_->GetRelativeLinearVel();
+    ignition::math::Vector3d current_angular_velocity = parent_->GetRelativeAngularVel();
 #endif
     float yaw = pose.Rot().Yaw();
+
     parent_->SetLinearVel(ignition::math::Vector3d(
           x_ * cosf(yaw) - y_ * sinf(yaw),
           y_ * cosf(yaw) + x_ * sinf(yaw),
           0));
-    parent_->SetAngularVel(ignition::math::Vector3d(0, 0, rot_));
+    parent_->SetAngularVel(ignition::math::Vector3d(current_angular_velocity.X(), current_angular_velocity.Y(), rot_));
     if (odometry_rate_ > 0.0) {
 #if GAZEBO_MAJOR_VERSION >= 8
       common::Time current_time = parent_->GetWorld()->SimTime();
@@ -203,7 +212,31 @@ namespace gazebo
         last_odom_publish_time_ = current_time;
       }
     }
+ROS_WARN_STREAM_THROTTLE(1, "UpdateBegin");
   }
+  
+  void GazeboRosPlanarMove::UpdateChildEnd()
+  {
+    boost::mutex::scoped_lock scoped_lock(lock);
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Pose3d pose = parent_->WorldPose();
+    ignition::math::Vector3d current_linear_velocity = parent_->RelativeLinearVel();
+    ignition::math::Vector3d current_angular_velocity = parent_->RelativeAngularVel();
+#else
+    ignition::math::Pose3d pose = parent_->GetWorldPose().Ign();
+    ignition::math::Vector3d current_linear_velocity = parent_->GetRelativeLinearVel();
+    ignition::math::Vector3d current_angular_velocity = parent_->GetRelativeAngularVel();
+#endif
+    float yaw = pose.Rot().Yaw();
+
+ROS_INFO_STREAM_THROTTLE(1, "UpdateEnd");
+    
+    ignition::math::Quaterniond current_orientation = pose.Rot();
+    ignition::math::Vector3d current_position = pose.Pos();
+    current_position.Z(0);
+    current_orientation.Euler(0,0,current_orientation.Yaw());
+    parent_->SetWorldPose(ignition::math::Pose3d(current_position, current_orientation));
+    }
 
   // Finalize the controller
   void GazeboRosPlanarMove::FiniChild() {


### PR DESCRIPTION
Removes tilting arround X and Y axis in the RosPlanarMove plugin.

What happens:
- If a robot with a high load at a high height moves using RosPlanar plugin, it can tilt arroing X and Y axis due to the simulation, but does not come back at a flat position at the desired speed.
- Probably is due to some interference between plugins.

Solution:
- Add a callback called after physics simulation to get rid of X/Y tilting.

Issue:
- With this option, robot cannot move through slopes.

How to use:
- Add the following tag to the URDF/Gazebo description 
`<disablePitchAndRoll>true</disablePitchAndRoll>`